### PR TITLE
Adds CubeMap based Dominant Light Extraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,13 @@ install(TARGETS cubemapPacker
   RUNTIME DESTINATION bin
 )
 
+add_executable(extractLight extractLight.cpp Cubemap.cpp)
+target_link_libraries(extractLight ${TBB_LIBRARIES} ${PNG_LIBRARY} ${OIIO_LIBRARY} ${Boost_LIBRARIES} )
+
+install(TARGETS extractLight
+  RUNTIME DESTINATION bin
+)
+
 
 add_executable(envPrefilter envPrefilter.cpp Cubemap.cpp)
 target_link_libraries(envPrefilter ${TBB_LIBRARIES} ${OIIO_LIBRARY} ${Boost_LIBRARIES} )

--- a/Cubemap
+++ b/Cubemap
@@ -70,6 +70,9 @@ struct Cubemap {
 
     Cubemap* shFilterCubeMap(bool useSolidAngleWeighting, int fixupType, int outputCubemapSize = 256 );
 
+    float computeImageMaxLuminosity ( const float * const pixels, const int stride, const uint width);
+    // using hierachical max luminosity pixel to find light direction
+    void  computeMainLightDirection();
     void fixupCubeEdges( const std::string& output, int level);
     void computePrefilterCubemapAtLevel( float roughness, const Cubemap& inputCubemap, uint numSamples, bool fixup );
 

--- a/extractLight.cpp
+++ b/extractLight.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <getopt.h>
+#include <cstdlib>
+#include <sstream>
+#include <unistd.h>
+#include <limits>
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+
+#include "Math"
+#include "Cubemap"
+#include "Color"
+
+
+
+static int usage(const std::string& name)
+{
+    std::cerr << "Usage: " << name << " input " << std::endl;
+    std::cerr << "eg: " << name << "input_%i.tiff " << std::endl;
+
+    return 1;
+}
+
+// mipmapped cubemap only
+int main(int argc, char** argv)
+{
+
+    std::string input;
+
+    int c;
+
+    while ((c = getopt (argc, argv, "")) != -1);
+
+    if ( optind < argc ) {
+
+        input = std::string( argv[optind] );
+
+        Cubemap elight;
+
+        if ( input.find("%") != std::string::npos )
+            elight.loadMipMap(input);
+        else
+            elight.load(input);
+
+        elight.computeMainLightDirection ();
+
+    } else {
+        return usage( argv[0] );
+    }
+
+    return 0;
+}


### PR DESCRIPTION
We want to get envmap lights extraction to be able to cast shadow,
compute visibility,etc.

Using cubemap mipmap we loop to get brightest pixel spot, hierarchically
recursing into mipmap, (thus not parsing all the images )

![](https://s3.amazonaws.com/uploads.hipchat.com/59700/410117/6p6yIitqFUx7g6m/debug_9_2.png)
